### PR TITLE
Check menuId to enable one entry to be part of multiple menus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,61 +57,61 @@ This will let you build your own HTML menu with Twig Macros.
 
 Sample custom menu:
 
+{% import _self as macros %}
+{% macro menu(node,menuId) %}
     {% import _self as macros %}
-    {% macro menu(node) %}
-        {% import _self as macros %}
-        {% set Grandchildren = craft.Navigation.renderChildren(node) %}
-        {% if Grandchildren | length > (0) %}
-            <ul>
-                {% for grandchildren in Grandchildren  %}
-                    <li>
-                        <a href="{% if craft.entries.id(grandchildren.NodeId).one().uri is defined %}/{{craft.entries.id(grandchildren.NodeId).one().uri}}{% else %}{{ grandchildren.menuUrl }}  {% endif %}">{{ grandchildren.NodeName }}</a>
-                        {{ macros.menu(grandchildren.NodeId) }}
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-    {% endmacro %}
-    
-    
-    <ul>
-    {% set MenuNodes=craft.Navigation.getRawNav('MenuName') %}
-       {% if MenuNodes is defined  %}
-            {% if MenuNodes is iterable %}
-    
-                {% for MenuNode in MenuNodes %}
-    
-                       {% if MenuNode.ParenNode == (0)  %}
-    
-                           {% if craft.Navigation.renderChildren(MenuNode.NodeId) is iterable %}
-                               <li>
-    
-                                   <a href="{% if craft.entries.id(MenuNode.NodeId).one().uri is defined %}/{{craft.entries.id(MenuNode.NodeId).one().uri}}{% else %}{{ MenuNode.menuUrl }}  {% endif %}">{{ MenuNode.NodeName }}</a>
-                                  
-                                 {% if craft.Navigation.renderChildren(MenuNode.NodeId) | length %}
-                                   <ul>
-                                      {% for childrenMenu in  craft.Navigation.renderChildren(MenuNode.NodeId) %}
-                                          <li>
-                                              <a href="{% if craft.entries.id(childrenMenu.NodeId).one().uri is defined %}/{{craft.entries.id(childrenMenu.NodeId).one().uri}}{% else %}{{ childrenMenu.menuUrl }}  {% endif %}">{{ childrenMenu.NodeName }}</a>
-                                              {{ macros.menu(childrenMenu.NodeId) }}
-    
-                                          </li>
-                                       {% endfor %}
-    
-                                   </ul>
-                                     {% endif %}
-                               </li>
-                               {% else %}
-    
-                            {% endif %}
-                    {% else %}
-                    {% endif %}
-    
-                {% endfor %}
+    {% set Grandchildren = craft.Navigation.renderChildren(node,menuId) %}
+    {% if Grandchildren | length > (0) %}
+        <ul>
+            {% for grandchildren in Grandchildren  %}
+                <li>
+                    <a href="{% if craft.entries.id(grandchildren.NodeId).one().uri is defined %}/{{craft.entries.id(grandchildren.NodeId).one().uri}}{% else %}{{ grandchildren.menuUrl }}  {% endif %}">{{ grandchildren.NodeName }}</a>
+                    {{ macros.menu(grandchildren.NodeId,grandchildren.menuId) }}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endmacro %}
+
+
+<ul>
+{% set MenuNodes=craft.Navigation.getRawNav('MenuName') %}
+   {% if MenuNodes is defined  %}
+        {% if MenuNodes is iterable %}
+
+            {% for MenuNode in MenuNodes %}
+
+                   {% if MenuNode.ParenNode == (0)  %}
+
+                       {% if craft.Navigation.renderChildren(MenuNode.NodeId,MenuNode.menuId) is iterable %}
+                           <li>
+
+                               <a href="{% if craft.entries.id(MenuNode.NodeId).one().uri is defined %}/{{craft.entries.id(MenuNode.NodeId).one().uri}}{% else %}{{ MenuNode.menuUrl }}  {% endif %}">{{ MenuNode.NodeName }}</a>
+                              
+                             {% if craft.Navigation.renderChildren(MenuNode.NodeId,MenuNode.menuId) | length %}
+                               <ul>
+                                  {% for childrenMenu in  craft.Navigation.renderChildren(MenuNode.NodeId,MenuNode.menuId) %}
+                                      <li>
+                                          <a href="{% if craft.entries.id(childrenMenu.NodeId).one().uri is defined %}/{{craft.entries.id(childrenMenu.NodeId).one().uri}}{% else %}{{ childrenMenu.menuUrl }}  {% endif %}">{{ childrenMenu.NodeName }}</a>
+                                          {{ macros.menu(childrenMenu.NodeId,childrenMenu.menuId) }}
+
+                                      </li>
+                                   {% endfor %}
+
+                               </ul>
+                                 {% endif %}
+                           </li>
+                           {% else %}
+
+                        {% endif %}
+                {% else %}
                 {% endif %}
-    {% else %}
-     {% endif %}
-    </ul>
+
+            {% endfor %}
+            {% endif %}
+{% else %}
+ {% endif %}
+</ul>
 
 
 Brought to you by [Fatfish](https://fatfish.com.au)

--- a/src/assetbundles/navigation/dist/js/Navigation.js
+++ b/src/assetbundles/navigation/dist/js/Navigation.js
@@ -293,11 +293,12 @@ function removeMenuNode($this) {
                 $id='#'+$this.attr('id');
                 Craft.postActionRequest('/craftnavigation/deletenode',{id:$this.attr('id')});
                 $($id).remove();
+                var $menuId = $('#menuid').val();
                 var $postData = [{menuname:$('#menuname').val(),siteId:Craft.siteId}];
                 var $SerializedMenu = $('ol.sortable').nestedSortable('toArray');
                 var $id= $('#menuid').val();
                 var $htmlmenu=$.trim($('#navigation-menu').html());
-                Craft.postActionRequest('/craftnavigation/save',{menuname:$postData,menuArray:$SerializedMenu,id:$id,menuhtml:$htmlmenu});
+                Craft.postActionRequest('/craftnavigation/save',{menuname:$postData,menuArray:$SerializedMenu,menuId:$menuId,id:$id,menuhtml:$htmlmenu});
                 $DeleteNodeModal.hide();
                 $DeleteNodeModal.destroy();
             });

--- a/src/controllers/NavigationController.php
+++ b/src/controllers/NavigationController.php
@@ -154,7 +154,8 @@
 
                 $MenuNode = new NavigationNodeElemenetRecord();
                 $NodeId = (int)str_replace('menuItem_','',Craft::$app->request->getBodyParam('id'));
-               if($MenuNode::deleteAll(['NodeId'=>$NodeId]))
+                $MenuId = (int)str_replace('menuItem_','',Craft::$app->request->getBodyParam('menuId'));
+               if($MenuNode::deleteAll(['NodeId'=>$NodeId,'menuId'=>$MenuId]))
                {
                    echo true;
                }

--- a/src/services/NavigationService.php
+++ b/src/services/NavigationService.php
@@ -103,9 +103,9 @@ class NavigationService extends Component
      * @param $nodeId
      * @return bool
      */
-    public function CheckNodeElementId($nodeId)
+    public function CheckNodeElementId($nodeId,$menuId)
     {
-        $NodeElementId = NavigationNodeElemenetRecord::find()->select('id')->where(['NodeId'=>$nodeId])->all();
+        $NodeElementId = NavigationNodeElemenetRecord::find()->select('id')->where(['NodeId'=>$nodeId,'menuId'=> $menuId] )->all();
         if(isset($NodeElementId[0]['id']))
         {
             return $NodeElementId[0]['id'];
@@ -122,7 +122,7 @@ class NavigationService extends Component
      */
     public function SaveNodeElement(NavigationNodeModel $model)
     {
-            $id=$this->CheckNodeElementId($model->NodeId);
+            $id=$this->CheckNodeElementId($model->NodeId,$model->menuId);
 
             if(!$id)
             {
@@ -202,10 +202,10 @@ class NavigationService extends Component
         $NavigationNodeElementRecord = new NavigationNodeElemenetRecord();
         return $NavigationNodeElementRecord::find()->where(['menuId'=>(int)$this->findByName($handleName)])->orderBy(['MenuOrder'=>'asc'])->all();
     }
-    public function GetChild($nodeId)
+    public function GetChild($nodeId,$menuId)
     {
         $NavigationNodeElementRecord = new NavigationNodeElemenetRecord();
-        return $NavigationNodeElementRecord::find()->where(['ParenNode'=>(int)$nodeId])->orderBy(['MenuOrder'=>'asc'])->all();
+        return $NavigationNodeElementRecord::find()->where(['ParenNode'=>(int)$nodeId,'menuId'=>(int)$menuId])->orderBy(['MenuOrder'=>'asc'])->all();
     }
     /*
      * param Navigation Model

--- a/src/variables/NavigationVariable.php
+++ b/src/variables/NavigationVariable.php
@@ -20,12 +20,10 @@
                 echo $template;
 
         }
-        public function renderChildren($NodeId)
+        public function renderChildren($NodeId,$menuId)
         {
 
-          return Navigation::$plugin->navigationService->GetChild($NodeId);
-
-
+          return Navigation::$plugin->navigationService->GetChild($NodeId,$menuId);
 
         }
 


### PR DESCRIPTION
Problem: If an entry was added to more than one menus, it was only related to the latest one saved. An entry could be part of only a single menu.

Fix: Check menuId to update/add menuItems (entries) on per menu basis. Sample custom menu example updated.

ToDo: Check craft.Navigation.render() - functionality with the update